### PR TITLE
Segfault fix for aflow slab functionality

### DIFF
--- a/src/structure/aflow_surface.cpp
+++ b/src/structure/aflow_surface.cpp
@@ -1876,7 +1876,8 @@ namespace slab {
     }
 
     const int In_Plane_Multiplication[3] = {0, 1, 1};    // In_Plane_Multiplication^2 = number of plane unit cells in slab unit cell
-    vector<int> NumAtomsForElementUC(2, 0);
+    //vector<int> NumAtomsForElementUC(str_in.num_each_type.size(), 0);
+    NumAtomsForElementUC(str_in.num_each_type.size(), 0);  //Adaptive array sizing based on number of unique elements in input POSCAR
     vector<vector<vector<double>>> AtomDirCoords;
     vector<vector<vector<int>>> LayerSitesDirCoords;
 


### PR DESCRIPTION
Dear all, I have made a fix for the aflow --slab functionality. Instead of a fixed vector size, which leads to index out of range errors, the vector sizing is now dynamic based on the actual number of elements in the POSCAR. Please refer to the commit for explicit details. This issue was observed when we were trying to build slabs from structures with more than 5 principal elements or when there is more than a certain number of atoms ( I cannot remember off the top of my head the exact values). 